### PR TITLE
Release v1.18.4

### DIFF
--- a/src/class-client.php
+++ b/src/class-client.php
@@ -406,6 +406,13 @@ class Client {
 			)
 		);
 
+		// For Simple sites get the response directly without any HTTP requests
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			add_filter( 'is_jetpack_authorized_for_site', '__return_true' );
+			require_lib( 'wpcom-api-direct' );
+			return \WPCOM_API_Direct::do_request( $validated_args );
+		}
+
 		return self::remote_request( $validated_args, $body );
 	}
 


### PR DESCRIPTION
This takes the changes made in D49507-code and brings them back into Jetpack.

There should be no changes for Jetpack sites. Simple sites will now be able to call the WPCOM API directly rather than doing an HTTP request.