### PR TITLE
Connection authorize URL: allow for jetpack plugin calypso env param

### DIFF
--- a/src/class-rest-connector.php
+++ b/src/class-rest-connector.php
@@ -713,14 +713,18 @@ class REST_Connector {
 	public function connection_authorize_url( $request ) {
 		$redirect_uri = $request->get_param( 'redirect_uri' ) ? admin_url( $request->get_param( 'redirect_uri' ) ) : null;
 
-		if ( ! $request->get_param( 'no_iframe' ) ) {
-			add_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
-		}
+		if ( class_exists( 'Jetpack' ) ) {
+			$authorize_url = \Jetpack::build_authorize_url( $redirect_uri, ! $request->get_param( 'no_iframe' ) );
+		} else {
+			if ( ! $request->get_param( 'no_iframe' ) ) {
+				add_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
+			}
 
-		$authorize_url = $this->connection->get_authorization_url( null, $redirect_uri );
+			$authorize_url = $this->connection->get_authorization_url( null, $redirect_uri );
 
-		if ( ! $request->get_param( 'no_iframe' ) ) {
-			remove_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
+			if ( ! $request->get_param( 'no_iframe' ) ) {
+				remove_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
+			}
 		}
 
 		return rest_ensure_response(


### PR DESCRIPTION
Local development doesn't work as expected when testing user connections because `define( 'CALYPSO_ENV', 'development' );` isn't respected when working with the Jetpack plugin.

Looking at `connection_register` (full connection) vs `connection_authorize_url` (user connection), then it works for full connections because it allows the Jetpack plugin to implement its own authorize URL logic.

This PR is a rough take, but mostly just documentation for the behaviour.
I haven't dug deeper to see if there is a prettier way to handle this, that will also support e.g. Jetpack Backup and other plugins.
